### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
     "inference interfaces"
   ],
   "description": "Label project images using detector and pose estimator",
-  "docker_image": "supervisely/base-py-sdk:6.73.456",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "min_instance_version": "6.15.2",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
     "inference interfaces"
   ],
   "description": "Label project images using detector and pose estimator",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,
@@ -19,7 +19,10 @@
   "icon": "https://user-images.githubusercontent.com/97401023/220315624-c6e79003-39fb-43e7-be48-ead1c9fae771.png",
   "icon_cover": true,
   "context_menu": {
-    "target": ["images_project", "images_dataset"],
+    "target": [
+      "images_project",
+      "images_dataset"
+    ],
     "context_root": "Neural Networks"
   },
   "poster": "https://user-images.githubusercontent.com/97401023/220315713-222c3b45-5ab1-4f07-8641-2a098f261b0c.png"

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   ],
   "description": "Label project images using detector and pose estimator",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "min_instance_version": "6.15.2",
+  "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.93
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
